### PR TITLE
Check there is a body before referencing a propety of it

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ Client.prototype.send = function (opts, cb) {
     self.statusCode = resp.statusCode;
     var ok = [200, 201, 202, 203, 204, 205, 206];
     if (ok.indexOf(resp.statusCode) === -1) {
-      return cb(body.error || body);
+      return cb((body && body.error) || body || resp.statusCode);
     }
     cb(null, body);
   });


### PR DESCRIPTION
Idiot was choking out if there wasn't a body in the response.  

```
/home/normal/tarragon-server/node_modules/idiot/index.js:62
      return cb(body.error || body);
                     ^

TypeError: Cannot read property 'error' of undefined
    at Object.callback (/home/normal/tarragon-server/node_modules/idiot/index.js:62:22)
    at cbOnce (/home/normal/tarragon-server/node_modules/xhr/index.js:62:21)
    at XMLHttpRequest.loadFunc [as onload] (/home/normal/tarragon-server/node_modules/xhr/index.js:129:16)
    at XMLHttpRequest._8b7‍.r.XMLHttpRequestEventTarget.dispatchEvent (/home/normal/tarragon-server/node_modules/xhr2/lib/xhr2.js:64:18)
    at XMLHttpRequest._8b7‍.r.XMLHttpRequest._dispatchProgress (/home/normal/tarragon-server/node_modules/xhr2/lib/xhr2.js:555:12)
    at XMLHttpRequest._8b7‍.r.XMLHttpRequest._onHttpResponseEnd (/home/normal/tarragon-server/node_modules/xhr2/lib/xhr2.js:510:12)
    at IncomingMessage.<anonymous> (/home/normal/tarragon-server/node_modules/xhr2/lib/xhr2.js:469:24)
    at emitNone (events.js:111:20)
    at IncomingMessage.emit (events.js:208:7)
    at endReadableNT (_stream_readable.js:1055:12)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickDomainCallback (internal/process/next_tick.js:218:9)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! tarragon-server@1.0.0 priceFeed: `node -r @std/esm src/priceFeed.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the tarragon-server@1.0.0 priceFeed script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/normal/.npm/_logs/2018-03-01T14_54_38_615Z-debug.log
```

I used https://httpstat.us/304 as a test url